### PR TITLE
Chinese GPT2推理fix

### DIFF
--- a/chinese_gpt2/infer.ipynb
+++ b/chinese_gpt2/infer.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "## 介绍\n",
     "这个是`chinese-gpt2`的推理代码\n",
     "1. 将`model_name_or_path = \"checkpoint-36000\"`里面的`\"checkpoint-36000\"`,修改为模型所在的路径。\n",
     "2. 然后运行下面一个代码块，即可输出文本生成结果"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -47,7 +47,7 @@
     "你是谁\n",
     "\"\"\"\n",
     "# encode context the generation is conditioned on\n",
-    "input_ids = tokenizer.encode(txt, return_tensors='pt')\n",
+    "input_ids = tokenizer.encode(txt, return_tensors='pt', add_special_tokens=False)\n",
     "# set no_repeat_ngram_size to 2\n",
     "beam_output = model.generate(\n",
     "    input_ids, \n",


### PR DESCRIPTION
`input_ids = tokenizer.encode(txt, return_tensors='pt')`
infer代码中使用bert tokenizer默认会在末尾加入特殊符号[SEP]，影响效果，改为
`input_ids = tokenizer.encode(txt, return_tensors='pt',add_special_tokens=True)`
效果如下:

> 你 是 谁 的 错? 我 和 男 朋 友 在 一 起 快 一 年 了, 我 们 是 大 学 同 学, 他 是 我 .......

代码中其他的diff是由于notebook保存时是个字典，无顺序，其实内容一致。